### PR TITLE
Gmail- Create and insert a draft email

### DIFF
--- a/gmail/snippet/send mail/create_draft.py
+++ b/gmail/snippet/send mail/create_draft.py
@@ -57,7 +57,6 @@ def gmail_create_draft():
         message['to'] = 'gduser1@workspacesamples.dev'
         message['from'] = 'gduser2@workspacesamples.dev'
         message['subject'] = 'Automated draft'
-        # encoding
         encoded_message = base64.urlsafe_b64encode\
             (message.as_string().encode()).decode()
 

--- a/gmail/snippet/send mail/create_draft.py
+++ b/gmail/snippet/send mail/create_draft.py
@@ -1,16 +1,19 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
 
 # [START gmail_create_draft]
 
@@ -27,7 +30,7 @@ from google.oauth2.credentials import Credentials
 SCOPES =['https://www.googleapis.com/auth/gmail.compose	']
 
 
-def gmailCreateDraft():
+def gmail_create_draft():
     """Create and insert a draft email.
        Print the returned draft's message and id.
       Returns: Draft object, including draft id and message meta data.
@@ -60,9 +63,10 @@ def gmailCreateDraft():
 
         create_message = {
             'message': {
-                'raw' : encoded_message
+                'raw': encoded_message
             }
         }
+        # pylint: disable=E1101
         draft = service.users().drafts().create(userId="me",
                                                 body=create_message).execute()
 
@@ -73,5 +77,5 @@ def gmailCreateDraft():
 
 
 if __name__ == '__main__':
-    gmailCreateDraft()
+    gmail_create_draft()
 # [END gmail_create_draft]


### PR DESCRIPTION
# Description

Create and insert a draft email.Print the returned draft's message and id. Returns Draft object, including draft id and message meta data.
Fixes # (210008391)

## Has it been tested?
- [x] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have performed a peer-reviewed with team member(s)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
