### PR TITLE
Gmail - create smime info and upload S/MIME certificate

### DIFF
--- a/gmail/snippet/smime snippets/create_smime_info.py
+++ b/gmail/snippet/smime snippets/create_smime_info.py
@@ -1,0 +1,44 @@
+"""Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# [START gmail_create_smime_info]
+
+from __future__ import print_function
+
+import base64
+
+
+def create_smime_info():
+    """Create an smimeInfo resource for a certificate from file.
+    Returns : Smime object, including smime information
+    """
+
+    smime_info = None
+    cert_password = None
+    cert_filename = 'humble_coder.csr'
+    try:
+        with open(cert_filename, 'rb') as cert:
+            smime_info = {}
+            data = cert.read().encode('UTF-8')
+            smime_info['pkcs12'] = base64.urlsafe_b64encode(data).decode()
+            if cert_password and len(cert_password) > 0:
+                smime_info['encryptedKeyPassword'] = cert_password
+
+    except (OSError, IOError) as error:
+        print(F'An error occurred while reading the certificate file: {error}')
+        smime_info = None
+
+    return smime_info
+
+
+if __name__ == '__main__':
+    print(create_smime_info())
+# [END gmail_create_smime_info]

--- a/gmail/snippet/smime snippets/insert_smime_info.py
+++ b/gmail/snippet/smime snippets/insert_smime_info.py
@@ -1,0 +1,60 @@
+"""Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# [START gmail_insert_smime_info]
+
+from __future__ import print_function
+
+import google.auth
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+import create_smime_info
+
+
+def insert_smime_info():
+    """Upload an S/MIME certificate for the user.
+    Print the inserted certificate's id
+    Returns : Result object with inserted certificate id and other meta-data
+
+    Load pre-authorized user credentials from the environment.
+    TODO(developer) - See https://developers.google.com/identity
+    for guides on implementing OAuth2 for the application.
+    """
+    creds, _ = google.auth.default()
+
+    try:
+        # create gmail api client
+        service = build('gmail', 'v1', credentials=creds)
+
+        user_id = 'gduser1@workspacesamples.dev'
+        smime_info = create_smime_info.create_smime_info()
+        send_as_email = None
+
+        if not send_as_email:
+            send_as_email = user_id
+
+        # pylint: disable=maybe-no-member
+        results = service.users().settings().sendAs().smimeInfo().\
+            insert(userId=user_id, sendAsEmail=send_as_email, body=smime_info)\
+            .execute()
+        print(F'Inserted certificate; id: {results["id"]}')
+
+    except HttpError as error:
+        print(F'An error occurred: {error}')
+        results = None
+
+    return results
+
+
+if __name__ == '__main__':
+    insert_smime_info()
+# [END gmail_insert_smime_info]


### PR DESCRIPTION
# Description

Create a smime Info resource for a certificate from file, returns smime object, including smime information.
Upload an S/MIME certificate for the user. Print the inserted certificate's id & returns result object with inserted certificate id and other meta-data

Fixes # (210008391)

## Has it been tested?
- [X] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have performed a peer-reviewed with team member(s)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
